### PR TITLE
GitHub Linguist support for adblock rules

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.txt linguist-language=AdBlock linguist-detectable

--- a/KmZ_filters.txt
+++ b/KmZ_filters.txt
@@ -1,3 +1,4 @@
+[uBlock Origin]
 !
 ! Title: [✔][list][new wave] "Rules, Filtering and exception list" - by K-mik@Z
 ! Expires: 1 days

--- a/KmZ_filters_no-chromecast.txt
+++ b/KmZ_filters_no-chromecast.txt
@@ -1,3 +1,4 @@
+[uBlock Origin]
 !
 ! Title: [✔][list][new wave] "Rules, Filtering, exception list and no-chromecast" - by K-mik@Z
 ! Version: 1

--- a/KmZ_filters_no-chromecast_with_antisocial_third-part.txt
+++ b/KmZ_filters_no-chromecast_with_antisocial_third-part.txt
@@ -1,3 +1,4 @@
+[uBlock Origin]
 !
 ! Title: [✔][list][new wave] "Rules, filtering, exception, blocking antisocial third-party and no chromecast" - by K-mik@Z
 ! Version: 1

--- a/KmZ_filters_with_antisocial_third-part.txt
+++ b/KmZ_filters_with_antisocial_third-part.txt
@@ -1,3 +1,4 @@
+[uBlock Origin]
 !
 ! Title: [✔][list][new wave] "Rules, filtering, exception list and blocking antisocial third-party" - by K-mik@Z
 ! Version: 1


### PR DESCRIPTION
GitHub has been supporting adblock syntax highlighting since September 5th. This PR will help you turn it on.

Further informations:
- Syntax highlighter repository: https://github.com/ameshkov/VscodeAdblockSyntax
- How Linguist works: https://github.com/github/linguist/blob/master/docs/how-linguist-works.md
- Linguist overrides: https://github.com/github/linguist/blob/master/docs/overrides.md
- Linguist commit: https://github.com/github/linguist/commit/e78ef71af3600f96b9a40a06511ebbe3797e7401